### PR TITLE
Add oredict support to composter

### DIFF
--- a/src/main/java/svenhjol/charm/crafting/feature/Composter.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Composter.java
@@ -4,7 +4,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.WorldClient;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -192,6 +191,9 @@ public class Composter extends Feature
     }
 
     public static boolean hasInput(ItemStack inputStack) {
+        if (inputStack.isEmpty())
+            return false;
+
         String itemName = ItemHelper.getItemStringFromItemStack(inputStack, true);
         if ( //Check the input list for either the itemname or the itemname without meta
                 Composter.inputs.containsKey(itemName)
@@ -200,24 +202,19 @@ public class Composter extends Feature
             return true;
         }
 
-        for (String input : inputs.keySet()) {
-            //Oredict entries start with `$`
-            if (input.startsWith("$")) {
-                if (
-                        OreDictionary.containsMatch(
-                                false,
-                                NonNullList.from(inputStack),
-                                (ItemStack[]) OreDictionary.getOres(input.substring(1)).toArray()
-                        )
-                ) {
-                    return true;
-                }
+        //Check for oredict entry
+        for (int id : OreDictionary.getOreIDs(inputStack)) {
+            if (Composter.inputs.containsKey("ore:"+OreDictionary.getOreName(id))) {
+                return true;
             }
         }
         return false;
     }
 
     public static float getItemChance(ItemStack inputStack) {
+        if (inputStack.isEmpty())
+            return 0.0f;
+
         String itemName = ItemHelper.getItemStringFromItemStack(inputStack, true);
         if (Composter.inputs.containsKey(itemName))
             return Composter.inputs.get(itemName);
@@ -227,17 +224,10 @@ public class Composter extends Feature
         if (Composter.inputs.containsKey(itemName))
             return Composter.inputs.get(itemName);
 
-        for (String input : inputs.keySet()) {
-            if (input.startsWith("$")) {
-                if (
-                        OreDictionary.containsMatch(
-                                false,
-                                NonNullList.from(inputStack),
-                                (ItemStack[]) OreDictionary.getOres(input.substring(1)).toArray()
-                        )
-                ) {
-                    return Composter.inputs.get(input);
-                }
+        //Check oredict
+        for (int id : OreDictionary.getOreIDs(inputStack)) {
+            if (Composter.inputs.containsKey("ore:"+OreDictionary.getOreName(id))) {
+                return Composter.inputs.get("ore:"+OreDictionary.getOreName(id));
             }
         }
         return 0.0f;

--- a/src/main/java/svenhjol/charm/crafting/tile/TileComposter.java
+++ b/src/main/java/svenhjol/charm/crafting/tile/TileComposter.java
@@ -108,20 +108,14 @@ public class TileComposter extends MesonTile
         } else {
 
             // check item and increase level based on item chance
-            String itemName = ItemHelper.getItemStringFromItemStack(inputStack, true);
-
-            if (!Composter.inputs.containsKey(itemName)) {
-                itemName = itemName.substring(0, itemName.indexOf('['));
-            }
-
-            // try again after stripping metadata bit
-            if (!Composter.inputs.containsKey(itemName)) return false;
+            if (!Composter.hasInput(inputStack))
+                return false;
 
             if (!world.isRemote) {
                 if (!keepInput) {
                     inputStack.shrink(1);
                 }
-                if (world.rand.nextFloat() < Composter.inputs.get(itemName)) {
+                if (world.rand.nextFloat() < Composter.getItemChance(inputStack)) {
                     newLevel++;
 
                     // let clients know the level has increased


### PR DESCRIPTION
Will close #173 when merged.

Entries can be added to the config file, prefixed with `ore:`. Entries are case-sensitive. I haven't added any entries to the default config file.

Video of it in action, with `ore:listAllseed` in the config file, and some Pam's Harvestcraft seeds: https://youtu.be/HUvnzWMfBNk