### PR TITLE
Added compatibility for mods that may generate new types of Netherrack

### DIFF
--- a/src/main/java/svenhjol/charm/base/compat/NetherModCompat.java
+++ b/src/main/java/svenhjol/charm/base/compat/NetherModCompat.java
@@ -1,0 +1,30 @@
+package svenhjol.charm.base.compat;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.pattern.BlockMatcher;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.Tag;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.gen.feature.OreFeatureConfig;
+
+import javax.annotation.Nullable;
+
+public class NetherModCompat {
+    private static Tag<Block> netherrackTag = new BlockTags.Wrapper(new ResourceLocation("forge", "netherrack"));
+    private static OreFeatureConfig.FillerBlockType fillerBlockType = OreFeatureConfig.FillerBlockType.create("NETHERRACK_TAG", "netherrack_tag", new BlockMatcher(Blocks.AIR){
+        @Override
+        public boolean test(@Nullable BlockState state) {
+            return state != null && netherrackTag.contains(state.getBlock());
+        }
+    });
+
+    public static Tag<Block> getNetherrackTag() {
+        return netherrackTag;
+    }
+
+    public static OreFeatureConfig.FillerBlockType getNetherrackTaggedFillerBlockType() {
+        return fillerBlockType;
+    }
+}

--- a/src/main/java/svenhjol/charm/world/module/NetherGoldDeposits.java
+++ b/src/main/java/svenhjol/charm/world/module/NetherGoldDeposits.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 import svenhjol.charm.Charm;
 import svenhjol.charm.base.CharmCategories;
+import svenhjol.charm.base.compat.NetherModCompat;
 import svenhjol.charm.world.block.NetherGoldDepositBlock;
 import svenhjol.meson.MesonModule;
 import svenhjol.meson.helper.ForgeHelper;
@@ -46,7 +47,7 @@ public class NetherGoldDeposits extends MesonModule {
             biome.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES,
                 Biome.createDecoratedFeature(ORE,
                     new OreFeatureConfig(
-                        OreFeatureConfig.FillerBlockType.NETHERRACK,
+                        NetherModCompat.getNetherrackTaggedFillerBlockType(),
                         block.getDefaultState(),
                         veinSize
                     ),

--- a/src/main/java/svenhjol/charm/world/module/NetherPigIron.java
+++ b/src/main/java/svenhjol/charm/world/module/NetherPigIron.java
@@ -9,6 +9,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.registries.ForgeRegistries;
 import svenhjol.charm.Charm;
 import svenhjol.charm.base.CharmCategories;
+import svenhjol.charm.base.compat.NetherModCompat;
 import svenhjol.charm.world.block.PigIronOreBlock;
 import svenhjol.charm.world.item.PigIronNuggetItem;
 import svenhjol.meson.MesonModule;
@@ -43,7 +44,7 @@ public class NetherPigIron extends MesonModule {
             biome.addFeature(GenerationStage.Decoration.UNDERGROUND_ORES,
                 Biome.createDecoratedFeature(ORE,
                     new OreFeatureConfig(
-                        OreFeatureConfig.FillerBlockType.NETHERRACK,
+                        NetherModCompat.getNetherrackTaggedFillerBlockType(),
                         block.getDefaultState(),
                         veinSize
                     ),


### PR DESCRIPTION
Currently Nether Gold deposits and Pig Iron only spawn in vanilla Netherrack. This is an issue for mods which add new types of Netherrack to the Nether. For example, my mod overrides the Nether to add custom biomes which each contain their own unique type of Netherrack. This change would allow for Nether Gold deposits and Pig Iron to spawn in my custom Netherrack types. This change also applies to any other mod as long as they tag their blocks.