### PR TITLE
1.12 improved Future MC compatibility, other small improvements

### DIFF
--- a/src/main/java/svenhjol/charm/base/CharmDecoratorItems.java
+++ b/src/main/java/svenhjol/charm/base/CharmDecoratorItems.java
@@ -9,8 +9,9 @@ import svenhjol.charm.brewing.block.BlockFlavoredCake;
 import svenhjol.charm.brewing.feature.FlavoredCake;
 import svenhjol.charm.crafting.block.BlockLantern;
 import svenhjol.charm.crafting.feature.Lantern;
-import svenhjol.meson.decorator.MesonInnerDecorator;
+import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.decorator.MesonDecoratorItems;
+import svenhjol.meson.decorator.MesonInnerDecorator;
 
 import javax.annotation.Nullable;
 
@@ -49,14 +50,18 @@ public class CharmDecoratorItems extends MesonDecoratorItems
 
     public void addLantern(int x, int y, int z, boolean hanging)
     {
-        if (!Charm.hasFeature(Lantern.class)) return;
-        generator.add(Lantern.getDefaultLantern().getDefaultState().withProperty(BlockLantern.HANGING, hanging), x, y, z, EnumFacing.NORTH);
+        if (Lantern.ironLantern == null && FutureMcBlocks.lanternHangingProperty != null)
+            generator.add(FutureMcBlocks.lantern.getDefaultState().withProperty(FutureMcBlocks.lanternHangingProperty, hanging), x, y, z, EnumFacing.NORTH);
+        else if (Charm.hasFeature(Lantern.class))
+            generator.add(Lantern.getDefaultLantern().getDefaultState().withProperty(BlockLantern.HANGING, hanging), x, y, z, EnumFacing.NORTH);
     }
 
     public IBlockState getLantern()
     {
         IBlockState state;
-        if (Charm.hasFeature(Lantern.class)) {
+        if (Lantern.ironLantern == null && FutureMcBlocks.lanternHangingProperty != null) {
+            state = FutureMcBlocks.lantern.getDefaultState().withProperty(FutureMcBlocks.lanternHangingProperty, false);
+        } else if (Charm.hasFeature(Lantern.class)) {
             state = Lantern.getDefaultLantern().getDefaultState();
         } else {
             state = Blocks.TORCH.getDefaultState();

--- a/src/main/java/svenhjol/charm/base/CharmDecoratorTheme.java
+++ b/src/main/java/svenhjol/charm/base/CharmDecoratorTheme.java
@@ -5,8 +5,9 @@ import net.minecraft.init.Blocks;
 import svenhjol.charm.Charm;
 import svenhjol.charm.crafting.feature.Barrel;
 import svenhjol.charm.crafting.feature.Crate;
-import svenhjol.meson.decorator.MesonInnerDecorator;
+import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.decorator.MesonDecoratorTheme;
+import svenhjol.meson.decorator.MesonInnerDecorator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,7 @@ public class CharmDecoratorTheme extends MesonDecoratorTheme
         List<IBlockState> states = new ArrayList<>();
         if (Charm.hasFeature(Crate.class)) states.add(Crate.crate.getDefaultState());
         if (Charm.hasFeature(Barrel.class)) states.add(Barrel.block.getDefaultState());
+        else if (FutureMcBlocks.barrel != null) states.add(FutureMcBlocks.barrel.getDefaultState());
         states.add(Blocks.CHEST.getDefaultState());
 
         return states.get(getRand().nextInt(states.size()));

--- a/src/main/java/svenhjol/charm/crafting/block/BlockLantern.java
+++ b/src/main/java/svenhjol/charm/crafting/block/BlockLantern.java
@@ -47,6 +47,13 @@ public class BlockLantern extends MesonBlock
         setDefaultState(blockState.getBaseState().withProperty(HANGING, false));
     }
 
+    @Nonnull
+    @Override
+    public Block setSoundType(@Nonnull SoundType sound)
+    {
+        return super.setSoundType(sound);
+    }
+
     @Override
     public String getModId()
     {

--- a/src/main/java/svenhjol/charm/crafting/compat/FutureMcSounds.java
+++ b/src/main/java/svenhjol/charm/crafting/compat/FutureMcSounds.java
@@ -1,0 +1,18 @@
+package svenhjol.charm.crafting.compat;
+
+import net.minecraft.block.SoundType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+public class FutureMcSounds
+{
+    public static SoundType getLanternSoundType()
+    {
+        SoundEvent lanternPlace = ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("futuremc", "lantern_place"));
+        SoundEvent lanternBreak = ForgeRegistries.SOUND_EVENTS.getValue(new ResourceLocation("futuremc", "lantern_break"));
+        
+        if (lanternPlace == null || lanternBreak == null) return null;
+        else return new SoundType(1.0f, 1.0f, lanternBreak, lanternPlace, lanternPlace, lanternBreak, lanternPlace);
+    }
+}

--- a/src/main/java/svenhjol/charm/crafting/feature/Barrel.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Barrel.java
@@ -8,6 +8,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import svenhjol.charm.Charm;
 import svenhjol.charm.crafting.block.BlockBarrel;
+import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
 import svenhjol.meson.helper.ForgeHelper;
@@ -62,7 +63,7 @@ public class Barrel extends Feature
         useCharmBarrels = propBoolean(
             "Use Charm barrels",
             "Charm's barrels will be enabled even if barrels from other mods are present.",
-            false
+            true
         );
 
         // internal
@@ -95,13 +96,24 @@ public class Barrel extends Feature
             types.put(rarity, barrels);
         }
 
-        // create recipes for all block barrel wood types
-        for (int i = 0; i < BlockBarrel.WoodVariant.values().length; i++) {
-            RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(block, 1, i),
-                "WSW", "W W", "WSW",
-                'W', ProxyRegistry.newStack(Blocks.PLANKS, 1, i),
-                'S', ProxyRegistry.newStack(Blocks.WOODEN_SLAB, 1, i)
-            );
+        if (FutureMcBlocks.barrel == null) {
+            // create recipes for all block barrel wood types
+            for (int i = 0; i < BlockBarrel.WoodVariant.values().length; i++) {
+                RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(block, 1, i),
+                    "WSW", "W W", "WSW",
+                    'W', ProxyRegistry.newStack(Blocks.PLANKS, 1, i),
+                    'S', ProxyRegistry.newStack(Blocks.WOODEN_SLAB, 1, i)
+                );
+            }
+        } else {
+            // create recipes for all block barrel wood types
+            for (int i = 0; i < BlockBarrel.WoodVariant.values().length; i++) {
+                RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(block, 1, i),
+                    "WWW", "S S", "WWW",
+                    'W', ProxyRegistry.newStack(Blocks.PLANKS, 1, i),
+                    'S', ProxyRegistry.newStack(Blocks.WOODEN_SLAB, 1, i)
+                );
+            }
         }
     }
 

--- a/src/main/java/svenhjol/charm/crafting/feature/Barrel.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Barrel.java
@@ -8,9 +8,9 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.oredict.OreDictionary;
 import svenhjol.charm.Charm;
 import svenhjol.charm.crafting.block.BlockBarrel;
-import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
+import svenhjol.meson.helper.ForgeHelper;
 import svenhjol.meson.helper.LootHelper;
 import svenhjol.meson.registry.ProxyRegistry;
 
@@ -51,7 +51,7 @@ public class Barrel extends Feature
     @Override
     public boolean isEnabled()
     {
-        return enabled && (FutureMcBlocks.barrel == null || useCharmBarrels);
+        return enabled && (!ForgeHelper.areModsLoaded("futuremc") || useCharmBarrels);
     }
 
     @Override
@@ -95,7 +95,7 @@ public class Barrel extends Feature
             types.put(rarity, barrels);
         }
 
-        if (FutureMcBlocks.barrel == null) {
+        if (!ForgeHelper.areModsLoaded("futuremc")) {
             // create recipes for all block barrel wood types
             for (int i = 0; i < BlockBarrel.WoodVariant.values().length; i++) {
                 RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(block, 1, i),
@@ -105,7 +105,7 @@ public class Barrel extends Feature
                 );
             }
         } else {
-            // create recipes for all block barrel wood types
+            // create alternate recipes for all block barrel wood types (only when FutureMC is present)
             for (int i = 0; i < BlockBarrel.WoodVariant.values().length; i++) {
                 RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(block, 1, i),
                     "WWW", "S S", "WWW",

--- a/src/main/java/svenhjol/charm/crafting/feature/Barrel.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Barrel.java
@@ -11,7 +11,6 @@ import svenhjol.charm.crafting.block.BlockBarrel;
 import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
-import svenhjol.meson.helper.ForgeHelper;
 import svenhjol.meson.helper.LootHelper;
 import svenhjol.meson.registry.ProxyRegistry;
 
@@ -52,7 +51,7 @@ public class Barrel extends Feature
     @Override
     public boolean isEnabled()
     {
-        return enabled && (!ForgeHelper.areModsLoaded("futuremc") || useCharmBarrels);
+        return enabled && (FutureMcBlocks.barrel == null || useCharmBarrels);
     }
 
     @Override

--- a/src/main/java/svenhjol/charm/crafting/feature/Composter.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Composter.java
@@ -69,7 +69,8 @@ public class Composter extends Feature
                         "inspirations:cactus_seeds",
                         "inspirations:sugar_cane_seeds",
                         "inspirations:carrot_seeds",
-                        "inspirations:potato_seeds"
+                        "inspirations:potato_seeds",
+                        "futuremc:sweet_berries"
                 }
         );
         for (String item : items) inputs.put(item, 0.3f);
@@ -112,7 +113,10 @@ public class Composter extends Feature
                         "inspirations:flower",
                         "inspirations:materials[4]",
                         "inspirations:materials[5]",
-                        "inspirations:edibles[0]"
+                        "inspirations:edibles[0]",
+                        "futuremc:cornflower",
+                        "futuremc:lily_of_the_valley",
+                        "futuremc:wither_rose"
                 }
         );
         for (String item : items) inputs.put(item, 0.65f);

--- a/src/main/java/svenhjol/charm/crafting/feature/Composter.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Composter.java
@@ -19,7 +19,6 @@ import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.NetworkHandler;
 import svenhjol.meson.handler.RecipeHandler;
-import svenhjol.meson.helper.ForgeHelper;
 import svenhjol.meson.helper.ItemHelper;
 import svenhjol.meson.helper.SoundHelper;
 import svenhjol.meson.registry.ProxyRegistry;
@@ -43,7 +42,7 @@ public class Composter extends Feature
     @Override
     public boolean isEnabled()
     {
-        return enabled && (!ForgeHelper.areModsLoaded("futuremc") || useCharmComposters);
+        return enabled && (FutureMcBlocks.composter == null || useCharmComposters);
     }
 
     @Override

--- a/src/main/java/svenhjol/charm/crafting/feature/Composter.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Composter.java
@@ -15,6 +15,7 @@ import net.minecraftforge.oredict.OreDictionary;
 import svenhjol.charm.Charm;
 import svenhjol.charm.crafting.block.BlockComposter;
 import svenhjol.charm.crafting.message.MessageComposterAddLevel;
+import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.NetworkHandler;
 import svenhjol.meson.handler.RecipeHandler;
@@ -177,11 +178,16 @@ public class Composter extends Feature
         GameRegistry.registerTileEntity(composter.getTileEntityClass(), new ResourceLocation(Charm.MOD_ID + ":composter"));
         NetworkHandler.register(MessageComposterAddLevel.class, Side.CLIENT);
 
-        RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(composter),
+        if (FutureMcBlocks.composter == null) {
+            RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(composter),
                 "F F", "F F", "PPP",
                 'F', "fenceWood",
                 'P', "plankWood"
-        );
+            );
+        } else {
+            RecipeHandler.addShapelessRecipe(ProxyRegistry.newStack(composter), new ItemStack(FutureMcBlocks.composter));
+            RecipeHandler.addShapelessRecipe(new ItemStack(FutureMcBlocks.composter), ProxyRegistry.newStack(composter));
+        }
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/svenhjol/charm/crafting/feature/Composter.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Composter.java
@@ -17,10 +17,11 @@ import svenhjol.charm.crafting.block.BlockComposter;
 import svenhjol.charm.crafting.message.MessageComposterAddLevel;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.NetworkHandler;
-import svenhjol.meson.helper.ItemHelper;
-import svenhjol.meson.registry.ProxyRegistry;
 import svenhjol.meson.handler.RecipeHandler;
+import svenhjol.meson.helper.ForgeHelper;
+import svenhjol.meson.helper.ItemHelper;
 import svenhjol.meson.helper.SoundHelper;
+import svenhjol.meson.registry.ProxyRegistry;
 
 import java.util.*;
 
@@ -30,11 +31,18 @@ public class Composter extends Feature
     public static Map<String, Float> inputs = new HashMap<>();
     public static List<String> outputs = new ArrayList<>();
     public static int maxOutput;
+    public static boolean useCharmComposters;
 
     @Override
     public String getDescription()
     {
         return "Right-click the composter with organic items to add them.  When the composter is full, bonemeal will be returned.";
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return enabled && (!ForgeHelper.areModsLoaded("futuremc") || useCharmComposters);
     }
 
     @Override
@@ -148,6 +156,12 @@ public class Composter extends Feature
                 "Maximum number of output items",
                 "Sets the maximum stack size of the composter output.",
                 3
+        );
+
+        useCharmComposters = propBoolean(
+                "Use Charm composters",
+                "Charm's composters will be enabled even if composters from other mods are present.",
+                false
         );
     }
 

--- a/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
@@ -3,10 +3,12 @@ package svenhjol.charm.crafting.feature;
 import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import svenhjol.charm.crafting.block.BlockLantern;
 import svenhjol.charm.crafting.compat.FutureMcSounds;
+import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
 import svenhjol.meson.helper.ForgeHelper;
@@ -64,13 +66,18 @@ public class Lantern extends Feature
     {
         super.preInit(event);
         if (useCharmLanterns || !ForgeHelper.areModsLoaded("futuremc")) {
-            // register iron lantern if not overridden by other mods
-            ironLantern = new BlockLantern("iron");
-            RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(ironLantern, numberOfLanterns),
-                "III", "ITI", "III",
-                'I', Items.IRON_NUGGET,
-                'T', Blocks.TORCH
-            );
+            if (ironLantern == null) {
+                // register iron lantern if not overridden by other mods
+                ironLantern = new BlockLantern("iron");
+                RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(ironLantern, numberOfLanterns),
+                    "III", "ITI", "III",
+                    'I', Items.IRON_NUGGET,
+                    'T', Blocks.TORCH
+                );
+            } else {
+                RecipeHandler.addShapelessRecipe(ProxyRegistry.newStack(ironLantern), new ItemStack(FutureMcBlocks.lantern));
+                RecipeHandler.addShapelessRecipe(new ItemStack(FutureMcBlocks.lantern), ProxyRegistry.newStack(ironLantern));
+            }
         }
 
         goldLantern = new BlockLantern("gold");

--- a/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
@@ -1,9 +1,12 @@
 package svenhjol.charm.crafting.feature;
 
+import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
+import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import svenhjol.charm.crafting.block.BlockLantern;
+import svenhjol.charm.crafting.compat.FutureMcSounds;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
 import svenhjol.meson.helper.ForgeHelper;
@@ -77,7 +80,17 @@ public class Lantern extends Feature
             'T', Blocks.TORCH
         );
     }
-
+    
+    @Override
+    public void init(FMLInitializationEvent event)
+    {
+        SoundType lanternSoundType = FutureMcSounds.getLanternSoundType();
+        if (lanternSoundType != null) {
+            if (ironLantern != null) ironLantern.setSoundType(lanternSoundType);
+            goldLantern.setSoundType(lanternSoundType);
+        }
+    }
+    
     public static BlockLantern getDefaultLantern()
     {
         return ironLantern == null ? goldLantern : ironLantern;

--- a/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
@@ -11,7 +11,6 @@ import svenhjol.charm.crafting.compat.FutureMcSounds;
 import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
-import svenhjol.meson.helper.ForgeHelper;
 import svenhjol.meson.registry.ProxyRegistry;
 
 public class Lantern extends Feature
@@ -65,7 +64,7 @@ public class Lantern extends Feature
     public void preInit(FMLPreInitializationEvent event)
     {
         super.preInit(event);
-        if (useCharmLanterns || !ForgeHelper.areModsLoaded("futuremc")) {
+        if (useCharmLanterns || ironLantern == null) {
             if (ironLantern == null) {
                 // register iron lantern if not overridden by other mods
                 ironLantern = new BlockLantern("iron");

--- a/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
+++ b/src/main/java/svenhjol/charm/crafting/feature/Lantern.java
@@ -4,13 +4,18 @@ import net.minecraft.block.SoundType;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import svenhjol.charm.crafting.block.BlockLantern;
 import svenhjol.charm.crafting.compat.FutureMcSounds;
 import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.Feature;
 import svenhjol.meson.handler.RecipeHandler;
+import svenhjol.meson.helper.ForgeHelper;
 import svenhjol.meson.registry.ProxyRegistry;
 
 public class Lantern extends Feature
@@ -64,18 +69,15 @@ public class Lantern extends Feature
     public void preInit(FMLPreInitializationEvent event)
     {
         super.preInit(event);
-        if (useCharmLanterns || ironLantern == null) {
-            if (ironLantern == null) {
-                // register iron lantern if not overridden by other mods
-                ironLantern = new BlockLantern("iron");
+        if (useCharmLanterns || !ForgeHelper.areModsLoaded("futuremc")) {
+            // register iron lantern if not overridden by other mods
+            ironLantern = new BlockLantern("iron");
+            if (!ForgeHelper.areModsLoaded("futuremc")) {
                 RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(ironLantern, numberOfLanterns),
                     "III", "ITI", "III",
                     'I', Items.IRON_NUGGET,
                     'T', Blocks.TORCH
                 );
-            } else {
-                RecipeHandler.addShapelessRecipe(ProxyRegistry.newStack(ironLantern), new ItemStack(FutureMcBlocks.lantern));
-                RecipeHandler.addShapelessRecipe(new ItemStack(FutureMcBlocks.lantern), ProxyRegistry.newStack(ironLantern));
             }
         }
 
@@ -86,7 +88,29 @@ public class Lantern extends Feature
             'T', Blocks.TORCH
         );
     }
-    
+
+    @SubscribeEvent(priority = EventPriority.HIGH)
+    public void onRegister(RegistryEvent.Register<IRecipe> event)
+    {
+        // Register recipe here only when FutureMC is present, inside preInit FutureMC blocks don't exist
+        if (FutureMcBlocks.lantern == null) {
+            RecipeHandler.addShapedRecipe(ProxyRegistry.newStack(ironLantern, numberOfLanterns),
+                "III", "ITI", "III",
+                'I', Items.IRON_NUGGET,
+                'T', Blocks.TORCH
+            );
+        } else {
+            RecipeHandler.addShapelessRecipe(ProxyRegistry.newStack(ironLantern), new ItemStack(FutureMcBlocks.lantern));
+            RecipeHandler.addShapelessRecipe(new ItemStack(FutureMcBlocks.lantern), ProxyRegistry.newStack(ironLantern));
+        }
+    }
+
+    @Override
+    public boolean hasSubscriptions()
+    {
+        return ForgeHelper.areModsLoaded("futuremc") && useCharmLanterns;
+    }
+
     @Override
     public void init(FMLInitializationEvent event)
     {

--- a/src/main/java/svenhjol/charm/world/compat/FutureMcBlocks.java
+++ b/src/main/java/svenhjol/charm/world/compat/FutureMcBlocks.java
@@ -1,0 +1,51 @@
+package svenhjol.charm.world.compat;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import svenhjol.charm.Charm;
+import svenhjol.charm.crafting.feature.Barrel;
+import svenhjol.charm.crafting.feature.Composter;
+import svenhjol.charm.crafting.feature.Lantern;
+
+public class FutureMcBlocks
+{
+    public static final Block barrel;
+    public static final Block composter;
+    public static final Block lantern;
+    public static final PropertyBool lanternHangingProperty;
+
+    static {
+        if (Charm.hasFeature(Barrel.class)) {
+            barrel = null;
+        } else {
+            barrel = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "barrel"));
+        }
+
+        if (Charm.hasFeature(Composter.class)) {
+            composter = null;
+        } else {
+            composter = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "composter"));
+        }
+
+        if (Charm.hasFeature(Lantern.class) && Lantern.ironLantern != null) {
+            lantern = null;
+            lanternHangingProperty = null;
+        } else {
+            lantern = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "lantern"));
+            PropertyBool property = null;
+            if (lantern != null) {
+                for (IProperty<?> propertyKey : lantern.getDefaultState().getPropertyKeys()) {
+                    if (propertyKey instanceof PropertyBool && propertyKey.getName().toLowerCase().equals("hanging")) {
+                        property = (PropertyBool) propertyKey;
+                        break;
+                    }
+                }
+            }
+
+            lanternHangingProperty = property;
+        }
+    }
+}

--- a/src/main/java/svenhjol/charm/world/compat/FutureMcBlocks.java
+++ b/src/main/java/svenhjol/charm/world/compat/FutureMcBlocks.java
@@ -5,47 +5,30 @@ import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.properties.PropertyBool;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import svenhjol.charm.Charm;
-import svenhjol.charm.crafting.feature.Barrel;
-import svenhjol.charm.crafting.feature.Composter;
-import svenhjol.charm.crafting.feature.Lantern;
 
 public class FutureMcBlocks
 {
+    // Only access this class if FutureMC blocks have been initialized, so generally after preInit
     public static final Block barrel;
     public static final Block composter;
     public static final Block lantern;
     public static final PropertyBool lanternHangingProperty;
 
     static {
-        if (Charm.hasFeature(Barrel.class)) {
-            barrel = null;
-        } else {
-            barrel = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "barrel"));
-        }
+        barrel = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "barrel"));
+        composter = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "composter"));
+        lantern = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "lantern"));
 
-        if (Charm.hasFeature(Composter.class)) {
-            composter = null;
-        } else {
-            composter = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "composter"));
-        }
-
-        if (Charm.hasFeature(Lantern.class) && Lantern.ironLantern != null) {
-            lantern = null;
-            lanternHangingProperty = null;
-        } else {
-            lantern = ForgeRegistries.BLOCKS.getValue(new ResourceLocation("futuremc", "lantern"));
-            PropertyBool property = null;
-            if (lantern != null) {
-                for (IProperty<?> propertyKey : lantern.getDefaultState().getPropertyKeys()) {
-                    if (propertyKey instanceof PropertyBool && propertyKey.getName().toLowerCase().equals("hanging")) {
-                        property = (PropertyBool) propertyKey;
-                        break;
-                    }
+        PropertyBool property = null;
+        if (lantern != null) {
+            for (IProperty<?> propertyKey : lantern.getDefaultState().getPropertyKeys()) {
+                if (propertyKey instanceof PropertyBool && propertyKey.getName().toLowerCase().equals("hanging")) {
+                    property = (PropertyBool) propertyKey;
+                    break;
                 }
             }
-
-            lanternHangingProperty = property;
         }
+
+        lanternHangingProperty = property;
     }
 }

--- a/src/main/java/svenhjol/charm/world/compat/ItemHandlerLootTableFiller.java
+++ b/src/main/java/svenhjol/charm/world/compat/ItemHandlerLootTableFiller.java
@@ -1,0 +1,58 @@
+package svenhjol.charm.world.compat;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldServer;
+import net.minecraft.world.storage.loot.LootContext;
+import net.minecraft.world.storage.loot.LootTable;
+import net.minecraftforge.items.IItemHandler;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class ItemHandlerLootTableFiller
+{
+    public static void fillWithLoot(IItemHandler inventory, World world, ResourceLocation lootTable, int lootSize)
+    {
+        if (!world.isRemote) {
+            LootTable table = world.getLootTableManager().getLootTableFromLocation(lootTable);
+            LootContext.Builder builder = new LootContext.Builder((WorldServer) world);
+
+            LootContext context = builder.build();
+            List<ItemStack> list = generateLootForPools(table, world.rand, context, lootSize);
+
+            List<Integer> slots = new ArrayList<>();
+            for (int i = 0; i < inventory.getSlots(); i++) {
+                slots.add(i);
+            }
+            Collections.shuffle(slots);
+
+            int i = 0;
+            for (ItemStack item : list) {
+                if (i >= inventory.getSlots()) continue;
+                inventory.insertItem(slots.get(i++), item, false);
+            }
+        }
+    }
+
+    private static List<ItemStack> generateLootForPools(LootTable table, Random rand, LootContext context, int lootSize)
+    {
+        List<ItemStack> loot = table.generateLootForPools(rand, context);
+
+        if (lootSize > 0) {
+            int i = 0;
+            while (loot.size() < lootSize && i++ < 10) {
+                loot.addAll(table.generateLootForPools(rand, context));
+            }
+
+            if (loot.size() > lootSize) {
+                loot = loot.subList(0, lootSize);
+            }
+        }
+
+        return loot;
+    }
+}

--- a/src/main/java/svenhjol/charm/world/decorator/outer/Barrels.java
+++ b/src/main/java/svenhjol/charm/world/decorator/outer/Barrels.java
@@ -7,11 +7,15 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
 import svenhjol.charm.Charm;
 import svenhjol.charm.base.CharmLootTables;
 import svenhjol.charm.crafting.feature.Barrel;
 import svenhjol.charm.crafting.feature.Composter;
 import svenhjol.charm.crafting.tile.TileBarrel;
+import svenhjol.charm.world.compat.FutureMcBlocks;
+import svenhjol.charm.world.compat.ItemHandlerLootTableFiller;
 import svenhjol.charm.world.feature.VillageDecorations;
 import svenhjol.meson.decorator.MesonOuterDecorator;
 
@@ -51,10 +55,27 @@ public class Barrels extends MesonOuterDecorator
                     if (tile instanceof TileBarrel) {
                         ((TileBarrel) tile).setLootTable(loot);
                     }
+                } else if (FutureMcBlocks.barrel != null) {
+                    world.setBlockState(current, FutureMcBlocks.barrel.getDefaultState());
+                    if (!world.isRemote) {
+                        continue;
+                    }
+
+                    TileEntity tile = world.getTileEntity(current);
+                    if (tile == null) {
+                        continue;
+                    }
+
+                    IItemHandler capability = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+                    if (capability != null) {
+                        ItemHandlerLootTableFiller.fillWithLoot(capability, world, loot, 0);
+                    }
                 }
             } else {
                 if (Charm.hasFeature(Composter.class)) {
                     world.setBlockState(current, Composter.composter.getDefaultState());
+                } else if (FutureMcBlocks.composter != null) {
+                    world.setBlockState(current, FutureMcBlocks.composter.getDefaultState());
                 }
             }
         }

--- a/src/main/java/svenhjol/charm/world/decorator/outer/Lights.java
+++ b/src/main/java/svenhjol/charm/world/decorator/outer/Lights.java
@@ -8,6 +8,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.World;
 import svenhjol.charm.Charm;
 import svenhjol.charm.crafting.feature.Lantern;
+import svenhjol.charm.world.compat.FutureMcBlocks;
 import svenhjol.meson.decorator.MesonOuterDecorator;
 
 import java.util.List;
@@ -35,8 +36,12 @@ public class Lights extends MesonOuterDecorator
             float f = rand.nextFloat();
             IBlockState light;
 
-            if (f > 0.93f && Charm.hasFeature(Lantern.class)) {
-                light = Lantern.getDefaultLantern().getDefaultState();
+            if (f > 0.93f && (Charm.hasFeature(Lantern.class) || FutureMcBlocks.lanternHangingProperty != null)) {
+                if (Lantern.ironLantern == null && FutureMcBlocks.lanternHangingProperty != null) {
+                    light = FutureMcBlocks.lantern.getDefaultState().withProperty(FutureMcBlocks.lanternHangingProperty, false);
+                } else {
+                    light = Lantern.getDefaultLantern().getDefaultState();
+                }
             } else if (f > 0.84f) {
                 light = Blocks.REDSTONE_TORCH.getDefaultState();
             } else {

--- a/src/main/java/svenhjol/meson/decorator/MesonDecoratorItems.java
+++ b/src/main/java/svenhjol/meson/decorator/MesonDecoratorItems.java
@@ -14,12 +14,16 @@ import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityChest;
+import net.minecraft.tileentity.TileEntityLockableLoot;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import net.minecraft.world.gen.structure.StructureComponent;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
+import svenhjol.charm.world.compat.ItemHandlerLootTableFiller;
 import svenhjol.meson.MesonTileInventory;
 import svenhjol.meson.helper.EntityHelper;
 
@@ -66,8 +70,13 @@ public class MesonDecoratorItems
 
         if (tile instanceof MesonTileInventory) {
             ((MesonTileInventory)tile).setLootTable(loot, lootSize);
-        } else if (tile instanceof TileEntityChest) {
+        } else if (tile instanceof TileEntityLockableLoot) {
             ((TileEntityChest)tile).setLootTable(loot, world.rand.nextLong());
+        } else if (tile != null) {
+            IItemHandler capability = tile.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null);
+            if (capability != null) {
+                ItemHandlerLootTableFiller.fillWithLoot(capability, world, loot, lootSize);
+            }
         }
     }
 

--- a/src/main/java/svenhjol/meson/helper/PlayerHelper.java
+++ b/src/main/java/svenhjol/meson/helper/PlayerHelper.java
@@ -1,10 +1,13 @@
 package svenhjol.meson.helper;
 
+import net.minecraft.entity.ai.attributes.AttributeMap;
+import net.minecraft.entity.ai.attributes.IAttributeInstance;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.SPacketEntityEffect;
+import net.minecraft.network.play.server.SPacketEntityProperties;
 import net.minecraft.network.play.server.SPacketRespawn;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
@@ -16,10 +19,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 public class PlayerHelper
 {
@@ -131,6 +131,12 @@ public class PlayerHelper
         for (PotionEffect potioneffect : player.getActivePotionEffects()) {
             player.connection.sendPacket(new SPacketEntityEffect(player.getEntityId(), potioneffect));
         }
+
+        AttributeMap attributeMap = (AttributeMap) player.getAttributeMap();
+        Collection<IAttributeInstance> watchedAttributes = attributeMap.getWatchedAttributes();
+        if (!watchedAttributes.isEmpty())
+            player.connection.sendPacket(new SPacketEntityProperties(player.getEntityId(), watchedAttributes));
+
         FMLCommonHandler.instance().firePlayerChangedDimensionEvent(player, oldDim, dimension);
     }
 }


### PR DESCRIPTION
List of changes:

- Improved lantern placement code, it should handle blocks under/above it better (so it won't hang under stuff like torches) and allow placing it by clicking on the side of a block instead of only the top/bottom part
- (Village) Decorators now use Future MC blocks when they're present and Charm variants aren't
- Charm composter accepts Future MC items/blocks (matches Future MC values)
- Charm lanterns use the same sound effects as Future MC ones (if Future MC is present)
- Teleportation between dimensions using methods introduced by Charm will transfer player attributes as it happens (so changes to max health, etc. will be preserved without having to find a way to refresh them)