### PR TITLE
Fix the woodcutter's saw spinning backwards (MC-190774)

### DIFF
--- a/src/main/resources/assets/charm/models/block/woodcutter.json
+++ b/src/main/resources/assets/charm/models/block/woodcutter.json
@@ -22,7 +22,7 @@
 			"to": [ 15, 16, 8 ],
 			"faces": {
 				"north": { "uv": [ 1, 9, 15, 16 ], "texture": "#saw", "tintindex": 0 },
-				"south": { "uv": [ 1, 9, 15, 16 ], "texture": "#saw", "tintindex": 0 }
+				"south": { "uv": [ 15, 9, 1, 16 ], "texture": "#saw", "tintindex": 0 }
 			}
 		}
 	]


### PR DESCRIPTION
This fixes [MC-190774](https://bugs.mojang.com/browse/MC-190774) for the woodcutter's model. Using the model in this pr makes it so the blade spins the same direction on both sides.