### PR TITLE
Fix being able to craft a vanilla chest from a vanilla chest

### DIFF
--- a/src/main/resources/data/charm/recipes/variant_chests/vanilla_chest_from_variant_chest.json
+++ b/src/main/resources/data/charm/recipes/variant_chests/vanilla_chest_from_variant_chest.json
@@ -2,7 +2,7 @@
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {
-      "tag": "charm:chests/normal"
+      "tag": "charm:chests/charm"
     }
   ],
   "result": {

--- a/src/main/resources/data/charm/tags/items/chests/charm.json
+++ b/src/main/resources/data/charm/tags/items/chests/charm.json
@@ -1,0 +1,15 @@
+{
+  "replace": false,
+  "values": [
+    "charm:acacia_chest",
+    "charm:azalea_chest",
+    "charm:birch_chest",
+    "charm:crimson_chest",
+    "charm:dark_oak_chest",
+    "charm:jungle_chest",
+    "charm:mangrove_chest",
+    "charm:oak_chest",
+    "charm:spruce_chest",
+    "charm:warped_chest"
+  ]
+}


### PR DESCRIPTION
While not a problem by itself, it however conflicts with Expanded Storage, which has a shapeless recipe for crafting its variant of the vanilla chest from a vanilla chest. Charm's recipe takes precedence and makes that impossible.

Tested by modifying the jar as I'm unable to get the `1.19.x` branch to build as-is. 🙁 

Fixes: #822