### PR TITLE
Kilns: add mod compat and a few stone variants

### DIFF
--- a/src/main/resources/data/charm/recipes/kilns/ae2/smooth_sky_stone_block.json
+++ b/src/main/resources/data/charm/recipes/kilns/ae2/smooth_sky_stone_block.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "ae2"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "ae2:sky_stone_block"
+  },
+  "result": "ae2:smooth_sky_stone_block",
+  "experience": 0.35,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_algal_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_algal_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:algal_bricks"
+  },
+  "result": "architects_palette:cracked_algal_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_basalt_tiles.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_basalt_tiles.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:basalt_tiles"
+  },
+  "result": "architects_palette:cracked_basalt_tiles",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_coal_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_coal_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:coal_ore_bricks"
+  },
+  "result": "architects_palette:cracked_coal_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_diamond_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_diamond_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:diamond_ore_bricks"
+  },
+  "result": "architects_palette:cracked_diamond_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_emerald_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_emerald_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:emerald_ore_bricks"
+  },
+  "result": "architects_palette:cracked_emerald_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_gold_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_gold_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:gold_ore_bricks"
+  },
+  "result": "architects_palette:cracked_gold_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_iron_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_iron_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:iron_ore_bricks"
+  },
+  "result": "architects_palette:cracked_iron_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_lapis_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_lapis_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:lapis_ore_bricks"
+  },
+  "result": "architects_palette:cracked_lapis_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_olivestone_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_olivestone_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:olivestone_bricks"
+  },
+  "result": "architects_palette:cracked_olivestone_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_olivestone_tiles.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_olivestone_tiles.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:olivestone_tiles"
+  },
+  "result": "architects_palette:cracked_olivestone_tiles",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_redstone_ore_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/cracked_redstone_ore_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:redstone_ore_bricks"
+  },
+  "result": "architects_palette:cracked_redstone_ore_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/heavy_cracked_end_stone_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/heavy_cracked_end_stone_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:heavy_end_stone_bricks"
+  },
+  "result": "architects_palette:heavy_cracked_end_stone_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/heavy_cracked_stone_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/heavy_cracked_stone_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:heavy_stone_bricks"
+  },
+  "result": "architects_palette:heavy_cracked_stone_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/architects_palette/smooth_nether_brass.json
+++ b/src/main/resources/data/charm/recipes/kilns/architects_palette/smooth_nether_brass.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "architects_palette"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "architects_palette:nether_brass_block"
+  },
+  "result": "architects_palette:smooth_nether_brass",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/biome_makeover/cracked_dried_peat_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/biome_makeover/cracked_dried_peat_bricks.json
@@ -1,0 +1,17 @@
+{
+  "type": "charm:firing",
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "biomemakeover"
+      ]
+    }
+  ],
+  "ingredient": {
+    "item": "biomemakeover:dried_peat_bricks"
+  },
+  "result": "biomemakeover:cracked_dried_peat_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/cracked_livingrock_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/cracked_livingrock_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:livingrock_bricks"
+  },
+  "result": "botania:cracked_livingrock_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_desert_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_desert_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_desert_cobblestone"
+  },
+  "result": "botania:metamorphic_desert_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_forest_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_forest_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_forest_cobblestone"
+  },
+  "result": "botania:metamorphic_forest_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_fungal_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_fungal_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_fungal_cobblestone"
+  },
+  "result": "botania:metamorphic_fungal_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_mesa_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_mesa_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_mesa_cobblestone"
+  },
+  "result": "botania:metamorphic_mesa_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_mountain_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_mountain_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_mountain_cobblestone"
+  },
+  "result": "botania:metamorphic_mountain_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_plains_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_plains_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_plains_cobblestone"
+  },
+  "result": "botania:metamorphic_plains_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_swamp_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_swamp_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_swamp_cobblestone"
+  },
+  "result": "botania:metamorphic_swamp_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_taiga_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/botania/metamorphic_taiga_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "botania"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "botania:metamorphic_taiga_cobblestone"
+  },
+  "result": "botania:metamorphic_taiga_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/black_glass.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/black_glass.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:black_sand"
+  },
+  "result": "minecraft:black_stained_glass",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/blue_glass.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/blue_glass.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:blue_sand"
+  },
+  "result": "minecraft:blue_stained_glass",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/cracked_red_rock_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/cracked_red_rock_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:red_rock_bricks"
+  },
+  "result": "byg:cracked_red_rock_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/cracked_scoria_stone_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/cracked_scoria_stone_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:scoria_stonebricks"
+  },
+  "result": "byg:cracked_scoria_stone_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/dacite.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/dacite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:dacite_cobblestone"
+  },
+  "result": "byg:dacite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/ether_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/ether_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:cobbled_ether_stone"
+  },
+  "result": "byg:ether_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/pink_glass.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/pink_glass.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:pink_sand"
+  },
+  "result": "minecraft:pink_stained_glass",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/purple_glass.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/purple_glass.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:purple_sand"
+  },
+  "result": "minecraft:purple_stained_glass",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/scoria.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/scoria.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:scoria_cobblestone"
+  },
+  "result": "byg:scoria_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/byg/white_glass.json
+++ b/src/main/resources/data/charm/recipes/kilns/byg/white_glass.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "byg"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "byg:white_sand"
+  },
+  "result": "minecraft:white_stained_glass",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/andesite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/andesite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_andesite"
+  },
+  "result": "minecraft:andesite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/basalt.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/basalt.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_basalt"
+  },
+  "result": "minecraft:basalt",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/black_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/black_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_black_terracotta"
+  },
+  "result": "minecraft:black_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/blackstone.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/blackstone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_blackstone"
+  },
+  "result": "minecraft:blackstone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/blue_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/blue_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_blue_terracotta"
+  },
+  "result": "minecraft:blue_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/brown_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/brown_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_brown_terracotta"
+  },
+  "result": "minecraft:brown_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/calcite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/calcite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_calcite"
+  },
+  "result": "minecraft:calcite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_andesite_pillar.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_andesite_pillar.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:andesite_pillar"
+  },
+  "result": "consistency_plus:cracked_andesite_pillar",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_carved_andesite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_carved_andesite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:carved_andesite"
+  },
+  "result": "consistency_plus:cracked_carved_andesite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_chiseled_andesite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_chiseled_andesite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:chiseled_andesite"
+  },
+  "result": "consistency_plus:cracked_chiseled_andesite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_polished_andesite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/cracked_polished_andesite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "minecraft:polished_andesite"
+  },
+  "result": "consistency_plus:cracked_polished_andesite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/cyan_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/cyan_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_cyan_terracotta"
+  },
+  "result": "minecraft:cyan_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/diorite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/diorite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_diorite"
+  },
+  "result": "minecraft:diorite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/dripstone.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/dripstone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_dripstone"
+  },
+  "result": "minecraft:dripstone_block",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/end_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/end_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_end_stone"
+  },
+  "result": "minecraft:end_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/granite.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/granite.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_granite"
+  },
+  "result": "minecraft:granite",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/gray_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/gray_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_gray_terracotta"
+  },
+  "result": "minecraft:gray_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/green_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/green_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_green_terracotta"
+  },
+  "result": "minecraft:green_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/light_blue_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/light_blue_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_light_blue_terracotta"
+  },
+  "result": "minecraft:light_blue_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/light_gray_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/light_gray_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_light_gray_terracotta"
+  },
+  "result": "minecraft:light_gray_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/lime_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/lime_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_lime_terracotta"
+  },
+  "result": "minecraft:lime_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/magenta_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/magenta_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_magenta_terracotta"
+  },
+  "result": "minecraft:magenta_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/netherrack.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/netherrack.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_netherrack"
+  },
+  "result": "minecraft:netherrack",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/orange_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/orange_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_orange_terracotta"
+  },
+  "result": "minecraft:orange_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/pink_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/pink_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_pink_terracotta"
+  },
+  "result": "minecraft:pink_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/purple_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/purple_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_purple_terracotta"
+  },
+  "result": "minecraft:purple_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/red_sandstone.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/red_sandstone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_red_sandstone"
+  },
+  "result": "minecraft:red_sandstone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/red_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/red_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_red_terracotta"
+  },
+  "result": "minecraft:red_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/sandstone.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/sandstone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_sandstone"
+  },
+  "result": "minecraft:sandstone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/soul_sandstone.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/soul_sandstone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_soul_sandstone"
+  },
+  "result": "consistency_plus:soul_sandstone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_terracotta"
+  },
+  "result": "minecraft:terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/tuff.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/tuff.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_tuff"
+  },
+  "result": "minecraft:tuff",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/white_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/white_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_white_terracotta"
+  },
+  "result": "minecraft:white_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/consistency_plus/yellow_terracotta.json
+++ b/src/main/resources/data/charm/recipes/kilns/consistency_plus/yellow_terracotta.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "consistency_plus"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "consistency_plus:cobbled_yellow_terracotta"
+  },
+  "result": "minecraft:yellow_terracotta",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/cracked_VARIANT_bricks.template.json
+++ b/src/main/resources/data/charm/recipes/kilns/cracked_VARIANT_bricks.template.json
@@ -11,6 +11,7 @@
   "variants": [
     "nether",
     "polished_blackstone",
-    "stone"
+    "stone",
+    "deepslate"
   ]
 }

--- a/src/main/resources/data/charm/recipes/kilns/cracked_deepslate_tiles.json
+++ b/src/main/resources/data/charm/recipes/kilns/cracked_deepslate_tiles.json
@@ -1,0 +1,9 @@
+{
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "minecraft:deepslate_tiles"
+  },
+  "result": "minecraft:cracked_deepslate_tiles",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/deepslate.json
+++ b/src/main/resources/data/charm/recipes/kilns/deepslate.json
@@ -1,0 +1,9 @@
+{
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "minecraft:cobbled_deepslate"
+  },
+  "result": "minecraft:deepslate",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/cracked_small_tainted_rock_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/cracked_small_tainted_rock_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:small_tainted_rock_bricks"
+  },
+  "result": "malum:cracked_small_tainted_rock_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/cracked_small_twisted_rock_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/cracked_small_twisted_rock_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:small_twisted_rock_bricks"
+  },
+  "result": "malum:cracked_small_twisted_rock_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/cracked_tainted_rock_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/cracked_tainted_rock_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:tainted_rock_bricks"
+  },
+  "result": "malum:cracked_tainted_rock_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/cracked_tainted_rock_tiles.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/cracked_tainted_rock_tiles.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:tainted_rock_tiles"
+  },
+  "result": "malum:cracked_tainted_rock_tiles",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/cracked_twisted_rock_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/cracked_twisted_rock_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:twisted_rock_bricks"
+  },
+  "result": "malum:cracked_twisted_rock_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/cracked_twisted_rock_tiles.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/cracked_twisted_rock_tiles.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:twisted_rock_tiles"
+  },
+  "result": "malum:cracked_twisted_rock_tiles",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/smooth_tainted_rock.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/smooth_tainted_rock.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:tainted_rock"
+  },
+  "result": "malum:smooth_tainted_rock",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/malum/smooth_twisted_rock.json
+++ b/src/main/resources/data/charm/recipes/kilns/malum/smooth_twisted_rock.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "malum"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "malum:twisted_rock"
+  },
+  "result": "malum:smooth_twisted_rock",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/paradise_lost/cracked_carved_stone.json
+++ b/src/main/resources/data/charm/recipes/kilns/paradise_lost/cracked_carved_stone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "the_aether"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "the_aether:carved_stone"
+  },
+  "result": "the_aether:cracked_carved_stone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/paradise_lost/holystone.json
+++ b/src/main/resources/data/charm/recipes/kilns/paradise_lost/holystone.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "the_aether"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "the_aether:cobbled_holystone"
+  },
+  "result": "the_aether:holystone",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/smooth_VARIANT.template.json
+++ b/src/main/resources/data/charm/recipes/kilns/smooth_VARIANT.template.json
@@ -11,6 +11,7 @@
   "variants": [
     "red_sandstone",
     "sandstone",
-    "stone"
+    "stone",
+    "basalt"
   ]
 }

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "minecraft:bricks"
+  },
+  "result": "twigs:cracked_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_cobblestone_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_cobblestone_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:cobblestone_bricks"
+  },
+  "result": "twigs:cracked_cobblestone_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_amethyst_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_amethyst_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:polished_amethyst_bricks"
+  },
+  "result": "twigs:cracked_polished_amethyst_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_bloodstone_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_bloodstone_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:polished_bloodstone_bricks"
+  },
+  "result": "twigs:cracked_polished_bloodstone_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_calcite_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_calcite_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:polished_calcite_bricks"
+  },
+  "result": "twigs:cracked_polished_calcite_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_rhyolite_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_rhyolite_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:polished_rhyolite_bricks"
+  },
+  "result": "twigs:cracked_polished_rhyolite_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_schist_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_schist_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:polished_schist_bricks"
+  },
+  "result": "twigs:cracked_polished_schist_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}

--- a/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_tuff_bricks.json
+++ b/src/main/resources/data/charm/recipes/kilns/twigs/cracked_polished_tuff_bricks.json
@@ -1,0 +1,17 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "twigs"
+      ]
+    }
+  ],
+  "type": "charm:firing",
+  "ingredient": {
+    "item": "twigs:polished_tuff_bricks"
+  },
+  "result": "twigs:cracked_polished_tuff_bricks",
+  "experience": 0.1,
+  "cookingtime": 100
+}


### PR DESCRIPTION
I originally made these recipes for my [modpack](https://modrinth.com/modpack/ariadne) but I figured I could contribute them to Charm itself. I used my own system to generate the mod compatibility JSONs, hopefully the Git repo isn't too cluttered.

Mod compat includes:
* AE2
* Architect's Palette
* Biome Makeover
* Botania
* BYG
* Consistency Plus (some useful recipes like Cobbled Andesite -> Andesite, but not nearly all of them)
* Malum
* Paradise Lost
* Twigs

I also added blackstone, deepslate and basalt `VARIANT`s to some vanilla Kiln recipes.