### PR TITLE
Fix a typo in "RespawnAnchorInTheEnd" module description

### DIFF
--- a/src/main/java/svenhjol/charm/module/respawn_anchor_in_the_end/RespawnAnchorInTheEnd.java
+++ b/src/main/java/svenhjol/charm/module/respawn_anchor_in_the_end/RespawnAnchorInTheEnd.java
@@ -5,7 +5,7 @@ import svenhjol.charm.Charm;
 import svenhjol.charm.annotation.CommonModule;
 import svenhjol.charm.loader.CharmModule;
 
-@CommonModule(mod = Charm.MOD_ID, enabledByDefault = false, description = "The repsawn anchor can be used in the End.\n" +
+@CommonModule(mod = Charm.MOD_ID, enabledByDefault = false, description = "The respawn anchor can be used in the End.\n" +
     "This is an opinionated feature that changes core gameplay and so is disabled by default.")
 public class RespawnAnchorInTheEnd extends CharmModule {
     public static boolean canSetSpawn(Level level) {


### PR DESCRIPTION
The "RespawnAnchorInTheEnd" had a typo saying "repsawn" instead of "respawn" in it's description