### PR TITLE
Improve and clean up mixins where possible for better mod compatibility

### DIFF
--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/anvil_repair/AnvilMenuMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/anvil_repair/AnvilMenuMixin.java
@@ -1,15 +1,15 @@
 package svenhjol.charm.charmony.common.mixin.event.anvil_repair;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.ItemCombinerMenu;
 import net.minecraft.world.inventory.MenuType;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.charmony.event.AnvilRepairEvent;
 
 import javax.annotation.Nullable;
@@ -31,15 +31,19 @@ public abstract class AnvilMenuMixin extends ItemCombinerMenu {
      * hook into ElytraItem's canRepair method directly is because
      * there is no world reference.
      */
-    @Redirect(
-        method = "createResult",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/item/Item;isValidRepairItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z"
-        )
+    @ModifyExpressionValue(
+            method = "createResult",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/item/Item;isValidRepairItem(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z"
+            )
     )
-    private boolean hookUpdateResultCanRepair(Item leftItem, ItemStack leftStack, ItemStack rightStack) {
+    private boolean hookUpdateResultCanRepair(boolean original,
+                                              @Local(ordinal = 0) ItemStack leftStack,
+                                              @Local(ordinal = 1) ItemStack leftItem,
+                                              @Local(ordinal = 2) ItemStack rightStack
+    ) {
         boolean result = AnvilRepairEvent.INSTANCE.invoke((AnvilMenu) (Object) this, this.player, leftStack, rightStack);
-        return result || leftItem.isValidRepairItem(leftStack, rightStack);
+        return result || original;
     }
 }

--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/block_break_speed_callback/PlayerMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/block_break_speed_callback/PlayerMixin.java
@@ -1,25 +1,23 @@
 package svenhjol.charm.charmony.common.mixin.event.block_break_speed_callback;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.callback.BlockBreakSpeedCallback;
 
 @SuppressWarnings("UnreachableCode")
 @Mixin(Player.class)
 public class PlayerMixin {
-    @Inject(
-        method = "getDestroySpeed",
-        at = @At("RETURN"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "getDestroySpeed",
+            at = @At("RETURN")
     )
-    private void hookGetDestroySpeed(BlockState state, CallbackInfoReturnable<Float> cir) {
+    private float hookGetDestroySpeed(float original, @Local(argsOnly = true) BlockState state) {
         var player = (Player)(Object)this;
-        var currentSpeed = cir.getReturnValue();
-        var newSpeed = BlockBreakSpeedCallback.EVENT.invoker().interact(player, state, currentSpeed);
-        cir.setReturnValue(newSpeed);
+        return BlockBreakSpeedCallback.EVENT.invoker().interact(player, state, original);
     }
 }

--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/grindstone/GrindstoneMenuInputMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/grindstone/GrindstoneMenuInputMixin.java
@@ -1,12 +1,12 @@
 package svenhjol.charm.charmony.common.mixin.event.grindstone;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.Container;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.event.GrindstoneEvents;
 
 @Mixin(targets = {
@@ -18,15 +18,15 @@ public class GrindstoneMenuInputMixin extends Slot {
         super(container, slot, x, y);
     }
 
-    @Inject(
-        method = "mayPlace(Lnet/minecraft/world/item/ItemStack;)Z",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "mayPlace(Lnet/minecraft/world/item/ItemStack;)Z",
+            at = @At("RETURN")
     )
-    private void hookMayPlace(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookMayPlace(boolean original, @Local(argsOnly = true) ItemStack stack) {
         var result = GrindstoneEvents.CAN_PLACE.invoke(container, stack);
         if (result) {
-            cir.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 }

--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/item_drag_drop/ItemMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/item_drag_drop/ItemMixin.java
@@ -1,5 +1,7 @@
 package svenhjol.charm.charmony.common.mixin.event.item_drag_drop;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.SlotAccess;
 import net.minecraft.world.entity.player.Player;
@@ -10,36 +12,47 @@ import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.event.ItemDragDropEvent;
 
 import javax.annotation.Nullable;
 
 @Mixin(Item.class)
 public class ItemMixin {
-    @Inject(
-        method = "overrideStackedOnOther",
-        at = @At("HEAD"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "overrideStackedOnOther",
+            at = @At("RETURN")
     )
-    private void hookOverrideStackedOnOther(ItemStack source, Slot slot, ClickAction clickAction, Player player, CallbackInfoReturnable<Boolean> ci) {
+    private boolean hookOverrideStackedOnOther(boolean original,
+                                               @Local(argsOnly = true) ItemStack source,
+                                               @Local(argsOnly = true) Slot slot,
+                                               @Local(argsOnly = true) ClickAction clickAction,
+                                               @Local(argsOnly = true) Player player
+    ) {
         var result = performStack(ItemDragDropEvent.StackType.STACKED_ON_OTHER, source, slot.getItem(), slot, clickAction, player, null);
         if (result != InteractionResult.PASS) {
-            ci.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 
-    @Inject(
-        method = "overrideOtherStackedOnMe",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "overrideOtherStackedOnMe",
+            at = @At("RETURN")
     )
-    private void hookOverrideOtherStackedOnMe(ItemStack source, ItemStack dest, Slot slot, ClickAction clickAction, Player player, SlotAccess slotAccess, CallbackInfoReturnable<Boolean> ci) {
+    private boolean hookOverrideOtherStackedOnMe(boolean original,
+                                                 @Local(ordinal = 0, argsOnly = true) ItemStack source,
+                                                 @Local(ordinal = 1, argsOnly = true) ItemStack dest,
+                                                 @Local(argsOnly = true) Slot slot,
+                                                 @Local(argsOnly = true) ClickAction clickAction,
+                                                 @Local(argsOnly = true) Player player,
+                                                 @Local(argsOnly = true) SlotAccess slotAccess
+    ) {
         var result = performStack(ItemDragDropEvent.StackType.STACKED_ON_SELF, source, dest, slot, clickAction, player, slotAccess);
         if (result != InteractionResult.PASS) {
-            ci.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 
     @Unique

--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/smithing_table/SmithingTransformRecipeMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/smithing_table/SmithingTransformRecipeMixin.java
@@ -1,5 +1,7 @@
 package svenhjol.charm.charmony.common.mixin.event.smithing_table;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.SmithingTransformRecipe;
@@ -8,8 +10,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.event.SmithingTableEvents;
 
 import java.util.List;
@@ -20,37 +20,37 @@ public class SmithingTransformRecipeMixin {
     @Shadow @Final
     Ingredient template;
 
-    @Inject(
-        method = "isTemplateIngredient",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "isTemplateIngredient",
+            at = @At("RETURN")
     )
-    private void hookIsTemplateIngredient(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookIsTemplateIngredient(boolean original, @Local(argsOnly = true) ItemStack stack) {
         if (SmithingTableEvents.VALIDATE_TEMPLATE.invoke(stack)) {
-            cir.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 
-    @Inject(
-        method = "isBaseIngredient",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "isBaseIngredient",
+            at = @At("RETURN")
     )
-    private void hookIsBaseIngredient(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookIsBaseIngredient(boolean original, @Local(argsOnly = true) ItemStack stack) {
         if (SmithingTableEvents.CAN_PLACE.invoke(getTemplate(), 1, stack)) {
-            cir.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 
-    @Inject(
-        method = "isAdditionIngredient",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "isAdditionIngredient",
+            at = @At("RETURN")
     )
-    private void hookIsAdditionIngredient(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookIsAdditionIngredient(boolean original, @Local(argsOnly = true) ItemStack stack) {
         if (SmithingTableEvents.CAN_PLACE.invoke(getTemplate(), 2, stack)) {
-            cir.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 
     @Unique
@@ -59,6 +59,6 @@ public class SmithingTransformRecipeMixin {
         if (items.isEmpty()) {
             return ItemStack.EMPTY;
         }
-        return items.get(0);
+        return items.getFirst();
     }
 }

--- a/src/main/java/svenhjol/charm/charmony/common/mixin/event/tooltip_component/ItemMixin.java
+++ b/src/main/java/svenhjol/charm/charmony/common/mixin/event/tooltip_component/ItemMixin.java
@@ -1,28 +1,29 @@
 package svenhjol.charm.charmony.common.mixin.event.tooltip_component;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.event.TooltipComponentEvent;
 
 import java.util.Optional;
 
 @Mixin(Item.class)
 public class ItemMixin {
-    @Inject(
-        method = "getTooltipImage",
-        at = @At("HEAD"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "getTooltipImage",
+            at = @At("RETURN")
     )
-    private void hookGetTooltipImage(ItemStack stack, CallbackInfoReturnable<Optional<TooltipComponent>> cir) {
+    private Optional<TooltipComponent> hookGetTooltipImage(Optional<TooltipComponent> original, @Local(argsOnly = true) ItemStack stack) {
         var tooltip = TooltipComponentEvent.INSTANCE.invoke(stack);
 
         if (tooltip.isPresent()) {
-            cir.setReturnValue(tooltip);
+            return tooltip;
         }
+        return original;
     }
 }

--- a/src/main/java/svenhjol/charm/feature/atlases/common/Handlers.java
+++ b/src/main/java/svenhjol/charm/feature/atlases/common/Handlers.java
@@ -75,10 +75,6 @@ public final class Handlers extends FeatureHolder<Atlases> {
      * @return True if the player has a map or the player has an atlas that has a map.
      */
     public boolean doesAtlasContainMap(Inventory inventory, Predicate<ItemStack> predicate) {
-        if (inventory.contains(predicate)) {
-            return true;
-        }
-
         for (var hand : InteractionHand.values()) {
             var atlasStack = inventory.player.getItemInHand(hand);
             if (atlasStack.getItem() == feature().registers.item.get()) {
@@ -93,7 +89,7 @@ public final class Handlers extends FeatureHolder<Atlases> {
     }
 
     public void setupAtlasUpscale(Inventory playerInventory, CartographyTableMenu container) {
-        var oldSlot = container.slots.get(0);
+        var oldSlot = container.slots.getFirst();
         container.slots.set(0, new Slot(oldSlot.container, oldSlot.index, oldSlot.x, oldSlot.y) {
             @Override
             public boolean mayPlace(ItemStack stack) {

--- a/src/main/java/svenhjol/charm/feature/core/custom_pistons/common/Handlers.java
+++ b/src/main/java/svenhjol/charm/feature/core/custom_pistons/common/Handlers.java
@@ -31,10 +31,7 @@ public final class Handlers extends FeatureHolder<CustomPistons> {
             feature().log().dev("found in piston_heads tag: " + block);
             found = state.is(Tags.PISTON_HEADS);
         }
-
-        if (found) return true;
-
-        // Fallthrough to default behavior
-        return state.is(block);
+        
+        return found;
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/animal_armor_enchanting/EnchantmentMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/animal_armor_enchanting/EnchantmentMixin.java
@@ -1,28 +1,29 @@
 package svenhjol.charm.mixin.feature.animal_armor_enchanting;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.feature.animal_armor_enchanting.AnimalArmorEnchanting;
 import svenhjol.charm.charmony.Resolve;
 
 @SuppressWarnings({"ConstantConditions", "UnreachableCode"})
 @Mixin(Enchantment.class)
 public class EnchantmentMixin {
-    @Inject(
-        method = "canEnchant",
-        at = @At("HEAD"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "canEnchant",
+            at = @At("RETURN")
     )
-    private void hookCanEnchant(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookCanEnchant(boolean original, @Local(argsOnly = true) ItemStack stack) {
         var enchantment = (Enchantment) (Object) this;
         var handlers = Resolve.feature(AnimalArmorEnchanting.class).handlers;
 
         if (handlers.isValidHorseEnchantment(stack, enchantment) || handlers.isValidWolfEnchantment(stack, enchantment)) {
-            cir.setReturnValue(true);
+            return true;
         }
+        return original;
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/animal_armor_enchanting/MobMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/animal_armor_enchanting/MobMixin.java
@@ -1,8 +1,8 @@
 package svenhjol.charm.mixin.feature.animal_armor_enchanting;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.animal.Wolf;
@@ -14,7 +14,6 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.feature.animal_armor_enchanting.AnimalArmorEnchanting;
 import svenhjol.charm.charmony.Resolve;
 
@@ -30,16 +29,16 @@ public abstract class MobMixin extends LivingEntity {
     /**
      * Always return the animal's body armor when a slot is requested.
      */
-    @Inject(
-        method = "getItemBySlot",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "getItemBySlot",
+            at = @At("RETURN")
     )
-    private void hookGetItemBySlot(EquipmentSlot equipmentSlot, CallbackInfoReturnable<ItemStack> cir) {
+    private ItemStack hookGetItemBySlot(ItemStack original) {
         var mob = (Mob)(Object)(this);
         if ((mob instanceof Wolf || mob instanceof Horse)) {
-            cir.setReturnValue(getBodyArmorItem());
+            return getBodyArmorItem();
         }
+        return original;
     }
 
     /**

--- a/src/main/java/svenhjol/charm/mixin/feature/animal_reviving/LivingEntityMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/animal_reviving/LivingEntityMixin.java
@@ -1,37 +1,37 @@
 package svenhjol.charm.mixin.feature.animal_reviving;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.OwnableEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.feature.animal_reviving.AnimalReviving;
 import svenhjol.charm.charmony.Resolve;
 
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin {
-    @Inject(
-        method = "shouldDropLoot",
-        at = @At("HEAD"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "shouldDropLoot",
+            at = @At("RETURN")
     )
-    private void hookShouldDropLoot(CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookShouldDropLoot(boolean original) {
         if (this instanceof OwnableEntity ownable
-            && ownable.getOwnerUUID() != null) {
-            cir.setReturnValue(Resolve.feature(AnimalReviving.class).dropLootOnDeath());
+                && ownable.getOwnerUUID() != null) {
+            return Resolve.feature(AnimalReviving.class).dropLootOnDeath();
         }
+        return original;
     }
 
-    @Inject(
-        method = "shouldDropExperience",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "shouldDropExperience",
+            at = @At("RETURN")
     )
-    private void hookShouldDropExperience(CallbackInfoReturnable<Boolean> cir) {
+    private boolean hookShouldDropExperience(boolean original) {
         if (this instanceof OwnableEntity ownable
-            && ownable.getOwnerUUID() != null) {
-            cir.setReturnValue(Resolve.feature(AnimalReviving.class).dropExperienceOnDeath());
+                && ownable.getOwnerUUID() != null) {
+            return Resolve.feature(AnimalReviving.class).dropExperienceOnDeath();
         }
+        return original;
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/atlases/MapItemSavedDataMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/atlases/MapItemSavedDataMixin.java
@@ -1,11 +1,12 @@
 package svenhjol.charm.mixin.feature.atlases;
 
-import net.minecraft.world.entity.player.Inventory;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.feature.atlases.Atlases;
 import svenhjol.charm.charmony.Resolve;
 
@@ -16,14 +17,15 @@ import java.util.function.Predicate;
  */
 @Mixin(MapItemSavedData.class)
 public class MapItemSavedDataMixin {
-    @Redirect(
-        method = "tickCarriedBy",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/entity/player/Inventory;contains(Ljava/util/function/Predicate;)Z"
-        )
+
+    @ModifyExpressionValue(
+            method = "tickCarriedBy",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/player/Inventory;contains(Ljava/util/function/Predicate;)Z"
+            )
     )
-    private boolean hookContains(Inventory inventory, Predicate<ItemStack> predicate) {
-        return Resolve.feature(Atlases.class).handlers.doesAtlasContainMap(inventory, predicate);
+    private boolean hookContains(boolean original, @Local(argsOnly = true) Player player, @Local Predicate<ItemStack> predicate) {
+        return original || Resolve.feature(Atlases.class).handlers.doesAtlasContainMap(player.getInventory(), predicate);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/casks/PotionBrewingMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/casks/PotionBrewingMixin.java
@@ -1,23 +1,26 @@
 package svenhjol.charm.mixin.feature.casks;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.alchemy.PotionBrewing;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.casks.Casks;
 
 @Mixin(PotionBrewing.class)
 public class PotionBrewingMixin {
-    @Inject(
-        method = "mix",
-        at = @At("RETURN"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "mix",
+            at = @At("RETURN")
     )
-    private void hookMix(ItemStack itemStack, ItemStack itemStack2, CallbackInfoReturnable<ItemStack> cir) {
-        var opt = Resolve.feature(Casks.class).handlers.restoreCustomPotionEffects(itemStack2, cir.getReturnValue());
-        opt.ifPresent(cir::setReturnValue);
+    private ItemStack hookMix(ItemStack original,
+                              @Local(ordinal = 0, argsOnly = true) ItemStack itemStack,
+                              @Local(ordinal = 1, argsOnly = true) ItemStack itemStack2
+    ) {
+        var opt = Resolve.feature(Casks.class).handlers.restoreCustomPotionEffects(itemStack2, original);
+        return opt.orElse(original);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/collection/BlockMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/collection/BlockMixin.java
@@ -1,46 +1,41 @@
 package svenhjol.charm.mixin.feature.collection;
 
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.collection.Collection;
 
+import java.util.function.Supplier;
+
 @Mixin(Block.class)
 public class BlockMixin {
-    @Inject(
-        method = "popResource(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/Block;popResource(Lnet/minecraft/world/level/Level;Ljava/util/function/Supplier;Lnet/minecraft/world/item/ItemStack;)V",
-            shift = At.Shift.BEFORE
-        ),
-        cancellable = true
+
+    @WrapWithCondition(
+            method = "popResource(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/item/ItemStack;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/Block;popResource(Lnet/minecraft/world/level/Level;Ljava/util/function/Supplier;Lnet/minecraft/world/item/ItemStack;)V"
+            )
     )
-    private static void checkPosAndCancelDrops(Level level, BlockPos pos, ItemStack stack, CallbackInfo ci) {
-        if (Resolve.feature(Collection.class).handlers.trySpawnToInventory(level, pos, stack)) {
-            ci.cancel();
-        }
+    private static boolean checkPosAndCancelDrops(Level level, Supplier<ItemEntity> supplier, ItemStack stack, @Local(argsOnly = true) BlockPos pos) {
+        return !Resolve.feature(Collection.class).handlers.trySpawnToInventory(level, pos, stack);
     }
-    
-    @Inject(
-        method = "popResourceFromFace",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/Block;popResource(Lnet/minecraft/world/level/Level;Ljava/util/function/Supplier;Lnet/minecraft/world/item/ItemStack;)V",
-            shift = At.Shift.BEFORE
-        ),
-        cancellable = true
+
+    @WrapWithCondition(
+            method = "popResourceFromFace",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/Block;popResource(Lnet/minecraft/world/level/Level;Ljava/util/function/Supplier;Lnet/minecraft/world/item/ItemStack;)V"
+            )
     )
-    private static void checkPosAndCancelDrops(Level level, BlockPos pos, Direction direction, ItemStack stack, CallbackInfo ci) {
-        if (Resolve.feature(Collection.class).handlers.trySpawnToInventory(level, pos, stack)) {
-            ci.cancel();
-        }
+    private static boolean checkPosAndCancelDropsFromFace(Level level, Supplier<ItemEntity> supplier, ItemStack stack, @Local(argsOnly = true) BlockPos pos) {
+        return !Resolve.feature(Collection.class).handlers.trySpawnToInventory(level, pos, stack);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/copper_pistons/PistonHeadBlockMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/copper_pistons/PistonHeadBlockMixin.java
@@ -1,8 +1,8 @@
 package svenhjol.charm.mixin.feature.copper_pistons;
 
-import net.minecraft.core.BlockPos;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.piston.PistonHeadBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
@@ -12,8 +12,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.copper_pistons.CopperPistons;
 
@@ -24,22 +22,21 @@ public class PistonHeadBlockMixin {
     @Final
     public static EnumProperty<PistonType> TYPE;
 
-    @Inject(
-        method = "getCloneItemStack",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "getCloneItemStack",
+            at = @At("RETURN")
     )
-    private void hookGetCloneItemStack(LevelReader levelReader, BlockPos blockPos, BlockState blockState, CallbackInfoReturnable<ItemStack> cir) {
+    private ItemStack hookGetCloneItemStack(ItemStack original, @Local(argsOnly = true) BlockState blockState) {
         if (isCopperPistonBlock()) {
             var copperPistons = Resolve.feature(CopperPistons.class);
             copperPistons.log().debug("changing itemstack to copper");
-            var newStack = new ItemStack(
-                blockState.getValue(TYPE) == PistonType.STICKY
-                    ? copperPistons.registers.stickyCopperPistonBlock.get()
-                    : copperPistons.registers.copperPistonBlock.get()
+            return new ItemStack(
+                    blockState.getValue(TYPE) == PistonType.STICKY
+                            ? copperPistons.registers.stickyCopperPistonBlock.get()
+                            : copperPistons.registers.copperPistonBlock.get()
             );
-            cir.setReturnValue(newStack);
         }
+        return original;
     }
 
     @Unique

--- a/src/main/java/svenhjol/charm/mixin/feature/copper_pistons/PistonHeadRendererMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/copper_pistons/PistonHeadRendererMixin.java
@@ -1,21 +1,19 @@
 package svenhjol.charm.mixin.feature.copper_pistons;
 
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.blockentity.PistonHeadRenderer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.copper_pistons.CopperPistons;
 
-@SuppressWarnings("UnnecessaryLocalVariable")
 @Mixin(PistonHeadRenderer.class)
 public class PistonHeadRendererMixin {
     @Unique
@@ -29,22 +27,21 @@ public class PistonHeadRendererMixin {
         isCopperPiston = blockEntity.getBlockState().is(Resolve.feature(CopperPistons.class).registers.movingCopperPistonBlock.get());
     }
 
-    @Redirect(
-        method = "render(Lnet/minecraft/world/level/block/piston/PistonMovingBlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/Block;defaultBlockState()Lnet/minecraft/world/level/block/state/BlockState;"
-        )
+    @ModifyReceiver(
+            method = "render(Lnet/minecraft/world/level/block/piston/PistonMovingBlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/Block;defaultBlockState()Lnet/minecraft/world/level/block/state/BlockState;"
+            )
     )
-    private BlockState modifyPistonHead(Block originalInstance) {
+    private Block modifyPistonHead(Block originalInstance) {
         Block newInstance = null;
 
         if (isCopperPistonBlock()) {
             newInstance = Resolve.feature(CopperPistons.class).registers.copperPistonHeadBlock.get();
         }
 
-        var state = (newInstance != null ? newInstance : originalInstance).defaultBlockState();
-        return state;
+        return newInstance != null ? newInstance : originalInstance;
     }
 
     @Unique

--- a/src/main/java/svenhjol/charm/mixin/feature/copper_pistons/PistonMovingBlockEntityMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/copper_pistons/PistonMovingBlockEntityMixin.java
@@ -1,5 +1,6 @@
 package svenhjol.charm.mixin.feature.copper_pistons;
 
+import com.llamalad7.mixinextras.injector.ModifyReceiver;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -9,33 +10,30 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.copper_pistons.CopperPistons;
 
-@SuppressWarnings("UnnecessaryLocalVariable")
 @Mixin(PistonMovingBlockEntity.class)
 public abstract class PistonMovingBlockEntityMixin extends BlockEntity {
     public PistonMovingBlockEntityMixin(BlockEntityType<?> blockEntityType, BlockPos blockPos, BlockState blockState) {
         super(blockEntityType, blockPos, blockState);
     }
 
-    @Redirect(
-        method = "getCollisionRelatedBlockState",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/Block;defaultBlockState()Lnet/minecraft/world/level/block/state/BlockState;"
-        )
+    @ModifyReceiver(
+            method = "getCollisionRelatedBlockState",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/Block;defaultBlockState()Lnet/minecraft/world/level/block/state/BlockState;"
+            )
     )
-    private BlockState modifyPistonHead(Block originalInstance) {
+    private Block modifyPistonHead(Block originalInstance) {
         Block newInstance = null;
 
         if (isCopperPistonBlock()) {
             newInstance = Resolve.feature(CopperPistons.class).registers.copperPistonHeadBlock.get();
         }
 
-        var state = (newInstance != null ? newInstance : originalInstance).defaultBlockState();
-        return state;
+        return newInstance != null ? newInstance : originalInstance;
     }
 
     @Unique

--- a/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonBaseBlockMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonBaseBlockMixin.java
@@ -1,35 +1,43 @@
 package svenhjol.charm.mixin.feature.core.custom_pistons;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.core.custom_pistons.CustomPistons;
 
 @Mixin(PistonBaseBlock.class)
 public class PistonBaseBlockMixin {
-    @Redirect(
-        method = {"checkIfExtend", "triggerEvent", "moveBlocks"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
-        )
+
+    @WrapOperation(
+            method = {"checkIfExtend", "triggerEvent", "moveBlocks"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
+            )
     )
-    private boolean redirectBlockStateChecks(BlockState state, Block block) {
-        return Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(state, block);
+    private boolean redirectBlockStateChecks(BlockState instance, Block block, Operation<Boolean> original) {
+        if (Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(instance, block)) {
+            return true;
+        }
+        return original.call(instance, block);
     }
 
-    @Redirect(
-        method = {"isPushable"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
-        )
+    @WrapOperation(
+            method = {"isPushable"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
+            )
     )
-    private static boolean redirectStaticBlockStateChecks(BlockState state, Block block) {
-        return Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(state, block);
+    private static boolean redirectStaticBlockStateChecks(BlockState instance, Block block, Operation<Boolean> original) {
+        if (Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(instance, block)) {
+            return true;
+        }
+        return original.call(instance, block);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonHeadBlockMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonHeadBlockMixin.java
@@ -1,24 +1,29 @@
 package svenhjol.charm.mixin.feature.core.custom_pistons;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.piston.PistonHeadBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.core.custom_pistons.CustomPistons;
 
 @Mixin(PistonHeadBlock.class)
 public class PistonHeadBlockMixin {
-    @Redirect(
-        method = {"isFittingBase", "canSurvive"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
-        )
+
+    @WrapOperation(
+            method = {"isFittingBase", "canSurvive"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
+            )
     )
-    private boolean redirectBlockStateChecks(BlockState state, Block block) {
-        return Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(state, block);
+    private boolean redirectBlockStateChecks(BlockState instance, Block block, Operation<Boolean> original) {
+        if (Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(instance, block)) {
+            return true;
+        }
+        return original.call(instance, block);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonHeadRendererMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonHeadRendererMixin.java
@@ -1,24 +1,29 @@
 package svenhjol.charm.mixin.feature.core.custom_pistons;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.client.renderer.blockentity.PistonHeadRenderer;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.core.custom_pistons.CustomPistons;
 
 @Mixin(PistonHeadRenderer.class)
 public class PistonHeadRendererMixin {
-    @Redirect(
-        method = "render(Lnet/minecraft/world/level/block/piston/PistonMovingBlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
-        )
+
+    @WrapOperation(
+            method = "render(Lnet/minecraft/world/level/block/piston/PistonMovingBlockEntity;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;II)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
+            )
     )
-    private boolean redirectBlockStateChecks(BlockState state, Block block) {
-        return Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(state, block);
+    private boolean redirectBlockStateChecks(BlockState instance, Block block, Operation<Boolean> original) {
+        if (Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(instance, block)) {
+            return true;
+        }
+        return original.call(instance, block);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonMovingBlockEntityMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/core/custom_pistons/PistonMovingBlockEntityMixin.java
@@ -1,35 +1,43 @@
 package svenhjol.charm.mixin.feature.core.custom_pistons;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.piston.PistonMovingBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.core.custom_pistons.CustomPistons;
 
 @Mixin(PistonMovingBlockEntity.class)
 public class PistonMovingBlockEntityMixin {
-    @Redirect(
-        method = {"finalTick"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
-        )
+
+    @WrapOperation(
+            method = {"finalTick"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
+            )
     )
-    private boolean redirectBlockStateChecks(BlockState state, Block block) {
-        return Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(state, block);
+    private boolean redirectBlockStateChecks(BlockState instance, Block block, Operation<Boolean> original) {
+        if (Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(instance, block)) {
+            return true;
+        }
+        return original.call(instance, block);
     }
 
-    @Redirect(
-        method = {"tick"},
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
-        )
+    @WrapOperation(
+            method = {"tick"},
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z"
+            )
     )
-    private static boolean redirectStaticBlockStateChecks(BlockState state, Block block) {
-        return Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(state, block);
+    private static boolean redirectStaticBlockStateChecks(BlockState instance, Block block, Operation<Boolean> original) {
+        if (Resolve.feature(CustomPistons.class).handlers.alsoCheckTags(instance, block)) {
+            return true;
+        }
+        return original.call(instance, block);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/core/custom_wood/LivingEntityMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/core/custom_wood/LivingEntityMixin.java
@@ -1,22 +1,23 @@
 package svenhjol.charm.mixin.feature.core.custom_wood;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import svenhjol.charm.feature.core.custom_wood.common.Tags;
 
 @Mixin(LivingEntity.class)
 public class LivingEntityMixin {
-    @Redirect(
-        method = "trapdoorUsableAsLadder",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
+
+    @ModifyExpressionValue(
+            method = "trapdoorUsableAsLadder",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z")
     )
-    private boolean hookTrapdoorUsableAsLadder(BlockState state, Block block) {
+    private boolean hookTrapdoorUsableAsLadder(boolean original, @Local(ordinal = 1) BlockState state) {
         return state.is(Tags.FABRIC_LADDERS);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/glint_coloring/RenderBuffersMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/glint_coloring/RenderBuffersMixin.java
@@ -1,5 +1,6 @@
 package svenhjol.charm.mixin.feature.glint_coloring;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import net.minecraft.client.renderer.RenderBuffers;
 import net.minecraft.client.renderer.RenderType;
@@ -7,7 +8,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.glint_coloring.GlintColoringClient;
 
@@ -19,11 +19,10 @@ public class RenderBuffersMixin {
      * Capture a reference to the buffer builders so we can add new elements to it.
      */
     @Inject(
-        method = "<init>",
-        at = @At("TAIL"),
-        locals = LocalCapture.CAPTURE_FAILHARD
+            method = "<init>",
+            at = @At("TAIL")
     )
-    private void hookInit(int i, CallbackInfo ci, SequencedMap<RenderType, ByteBufferBuilder> builders) {
+    private void hookInit(int i, CallbackInfo ci, @Local SequencedMap<RenderType, ByteBufferBuilder> builders) {
         Resolve.feature(GlintColoringClient.class).handlers.setBuilders(builders);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/glint_coloring/RenderTypeMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/glint_coloring/RenderTypeMixin.java
@@ -1,55 +1,51 @@
 package svenhjol.charm.mixin.feature.glint_coloring;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.client.renderer.RenderType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.glint_coloring.GlintColoringClient;
 import svenhjol.charm.feature.glint_coloring.client.Handlers;
 
 @Mixin(RenderType.class)
 public class RenderTypeMixin {
-    @Inject(
-        method = "armorEntityGlint",
-        at = @At("RETURN"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "armorEntityGlint",
+            at = @At("RETURN")
     )
-    private static void hookGetArmorEntityGlint(CallbackInfoReturnable<RenderType> cir) {
+    private static RenderType hookGetArmorEntityGlint(RenderType original) {
         var layer = glintColoring().getArmorEntityGlintRenderLayer();
-        cir.setReturnValue(layer != null ? layer : cir.getReturnValue());
+        return layer != null ? layer : original;
     }
 
-    @Inject(
-        method = "entityGlint",
-        at = @At("RETURN"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "entityGlint",
+            at = @At("RETURN")
     )
-    private static void hookGetEntityGlint(CallbackInfoReturnable<RenderType> cir) {
+    private static RenderType hookGetEntityGlint(RenderType original) {
         var layer = glintColoring().getEntityGlintRenderLayer();
-        cir.setReturnValue(layer != null ? layer : cir.getReturnValue());
+        return layer != null ? layer : original;
     }
 
-    @Inject(
-        method = "entityGlintDirect",
-        at = @At("RETURN"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "entityGlintDirect",
+            at = @At("RETURN")
     )
-    private static void hookGetEntityGlintDirect(CallbackInfoReturnable<RenderType> cir) {
+    private static RenderType hookGetEntityGlintDirect(RenderType original) {
         var layer = glintColoring().getDirectEntityGlintRenderLayer();
-        cir.setReturnValue(layer != null ? layer : cir.getReturnValue());
+        return layer != null ? layer : original;
     }
 
-    @Inject(
-        method = "glint",
-        at = @At("RETURN"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "glint",
+            at = @At("RETURN")
     )
-    private static void hookGetGlint(CallbackInfoReturnable<RenderType> cir) {
+    private static RenderType hookGetGlint(RenderType original) {
         var layer = glintColoring().getGlintRenderLayer();
-        cir.setReturnValue(layer != null ? layer : cir.getReturnValue());
+        return layer != null ? layer : original;
     }
 
     @Unique

--- a/src/main/java/svenhjol/charm/mixin/feature/item_restocking/ComposterBlockMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/item_restocking/ComposterBlockMixin.java
@@ -13,7 +13,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.item_restocking.ItemRestocking;
 
@@ -27,8 +26,7 @@ public class ComposterBlockMixin {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/level/Level;levelEvent(ILnet/minecraft/core/BlockPos;I)V"
-        ),
-        locals = LocalCapture.CAPTURE_FAILHARD
+        )
     )
     public void hookOnUse(ItemStack itemStack, BlockState blockState, Level level, BlockPos blockPos, Player player, InteractionHand interactionHand, BlockHitResult blockHitResult, CallbackInfoReturnable<ItemInteractionResult> cir) {
         Resolve.feature(ItemRestocking.class).handlers.addItemUsedStat(player, itemStack);

--- a/src/main/java/svenhjol/charm/mixin/feature/note_blocks/amethyst_note_block/BlockBehaviourPropertiesMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/note_blocks/amethyst_note_block/BlockBehaviourPropertiesMixin.java
@@ -1,5 +1,6 @@
 package svenhjol.charm.mixin.feature.note_blocks.amethyst_note_block;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -7,8 +8,6 @@ import net.minecraft.world.level.block.state.properties.NoteBlockInstrument;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.feature.note_blocks.amethyst_note_block.AmethystNoteBlock;
 
 import java.util.Locale;
@@ -18,15 +17,15 @@ public abstract class BlockBehaviourPropertiesMixin {
     @Shadow
     public abstract boolean is(Block block);
 
-    @Inject(
-        method = "instrument",
-        at = @At("HEAD"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "instrument",
+            at = @At("RETURN")
     )
-    private void hookInstrument(CallbackInfoReturnable<NoteBlockInstrument> cir) {
+    private NoteBlockInstrument hookInstrument(NoteBlockInstrument original) {
         if (is(Blocks.AMETHYST_BLOCK)) {
-            cir.setReturnValue(NoteBlockInstrument
-                .valueOf(AmethystNoteBlock.NOTE_BLOCK_ID.toUpperCase(Locale.ROOT)));
+            return NoteBlockInstrument
+                    .valueOf(AmethystNoteBlock.NOTE_BLOCK_ID.toUpperCase(Locale.ROOT));
         }
+        return original;
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/suspicious_effect_improvements/suspicious_big_plants/SuspiciousStewRecipeMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/suspicious_effect_improvements/suspicious_big_plants/SuspiciousStewRecipeMixin.java
@@ -1,5 +1,7 @@
 package svenhjol.charm.mixin.feature.suspicious_effect_improvements.suspicious_big_plants;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -7,21 +9,21 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.SuspiciousStewRecipe;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(SuspiciousStewRecipe.class)
 public class SuspiciousStewRecipeMixin {
-    @Redirect(
-        method = "matches(Lnet/minecraft/world/item/crafting/CraftingInput;Lnet/minecraft/world/level/Level;)Z",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/tags/TagKey;)Z"
-        )
+
+    @WrapOperation(
+            method = "matches(Lnet/minecraft/world/item/crafting/CraftingInput;Lnet/minecraft/world/level/Level;)Z",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/item/ItemStack;is(Lnet/minecraft/tags/TagKey;)Z"
+            )
     )
-    private boolean redirectItemTagCheck(ItemStack stack, TagKey<Item> tag) {
+    private boolean redirectItemTagCheck(ItemStack stack, TagKey<Item> tagKey, Operation<Boolean> original) {
         if (stack.is(Items.SUNFLOWER) || stack.is(Items.PITCHER_PLANT)) {
             return true;
         }
-        return stack.is(tag); // default behavior
+        return original.call(stack, tagKey); // default behavior
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/suspicious_effect_improvements/suspicious_effects_last_longer/FlowerBlockMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/suspicious_effect_improvements/suspicious_effects_last_longer/FlowerBlockMixin.java
@@ -1,25 +1,21 @@
 package svenhjol.charm.mixin.feature.suspicious_effect_improvements.suspicious_effects_last_longer;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.world.item.component.SuspiciousStewEffects;
 import net.minecraft.world.level.block.FlowerBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.suspicious_effect_improvements.suspicious_effects_last_longer.SuspiciousEffectsLastLonger;
 
 @Mixin(FlowerBlock.class)
 public abstract class FlowerBlockMixin {
 
-    @Inject(
-        method = "getSuspiciousEffects",
-        at = @At("RETURN"),
-        cancellable = true
+    @ModifyReturnValue(
+            method = "getSuspiciousEffects",
+            at = @At("RETURN")
     )
-    private void hookGetSuspiciousEffects(CallbackInfoReturnable<SuspiciousStewEffects> cir) {
-        var effects = cir.getReturnValue();
-        var modified = Resolve.feature(SuspiciousEffectsLastLonger.class).handlers.modifyEffects(effects);
-        cir.setReturnValue(modified);
+    private SuspiciousStewEffects hookGetSuspiciousEffects(SuspiciousStewEffects original) {
+        return Resolve.feature(SuspiciousEffectsLastLonger.class).handlers.modifyEffects(original);
     }
 }

--- a/src/main/java/svenhjol/charm/mixin/feature/torchflowers_emit_light/BlockBehaviourPropertiesMixin.java
+++ b/src/main/java/svenhjol/charm/mixin/feature/torchflowers_emit_light/BlockBehaviourPropertiesMixin.java
@@ -1,23 +1,22 @@
 package svenhjol.charm.mixin.feature.torchflowers_emit_light;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import svenhjol.charm.charmony.Resolve;
 import svenhjol.charm.feature.torchflowers_emit_light.TorchflowersEmitLight;
 
 @Mixin(BlockBehaviour.BlockStateBase.class)
 public abstract class BlockBehaviourPropertiesMixin {
-    @Inject(
-        method = "getLightEmission",
-        at = @At("HEAD"),
-        cancellable = true
+
+    @ModifyReturnValue(
+            method = "getLightEmission",
+            at = @At("RETURN")
     )
-    private void hookGetLightEmission(CallbackInfoReturnable<Integer> cir) {
-        Resolve.feature(TorchflowersEmitLight.class).handlers
-            .lightLevel((BlockBehaviour.BlockStateBase)(Object)this)
-            .ifPresent(cir::setReturnValue);
+    private int hookGetLightEmission(int original) {
+        return Resolve.feature(TorchflowersEmitLight.class).handlers
+                .lightLevel((BlockBehaviour.BlockStateBase)(Object)this)
+                .orElse(original);
     }
 }


### PR DESCRIPTION
Refactors a lot of mixins using features from [MixinExtras](https://github.com/LlamaLad7/MixinExtras):

- Cancellable injections which modified the return value were changed to use [`ModifyReturnValue`](https://github.com/LlamaLad7/MixinExtras/wiki/ModifyReturnValue) where possible, see link for an explanation on why this is preferable.
- `Redirect`s were replaced with better alternatives which provide better mod compatibility where possible, see `ModifyExpressionValue`, `WrapOperation`, `WrapWithCondition`, and `ModifyReceiver` on the [MixinExtras wiki](https://github.com/LlamaLad7/MixinExtras/wiki) for explanations on why this is preferable.
- A few Handler classes were slightly changed to adapt to the new mixins.
- Traditional local captures were replaced by [`@Local`](https://github.com/LlamaLad7/MixinExtras/wiki/Local) in order to clean up the code a bit in a few places.

I've tested all the features affected by these changes and they seem to be working, although additional testing would be welcome, just to make sure.