### PR TITLE
Update gunpowder_from_gunpowder_block.json

### DIFF
--- a/src/main/resources/data/charm/recipe/gunpowder_block/gunpowder_from_gunpowder_block.json
+++ b/src/main/resources/data/charm/recipe/gunpowder_block/gunpowder_from_gunpowder_block.json
@@ -6,7 +6,7 @@
     }
   ],
   "result": {
-    "id": "minecraft:sugar",
+    "id": "minecraft:gunpowder",
     "count": 9
   }
 }


### PR DESCRIPTION
Changed line 9: "id": "minecraft:sugar",
to "id": "minecraft:gunpowder",

Fixes returning gunpowder blocks into gunpowder.